### PR TITLE
Fix array not returning nothing on OOB read.

### DIFF
--- a/src/stasiak/karol/fimpp/Context.scala
+++ b/src/stasiak/karol/fimpp/Context.scala
@@ -121,8 +121,11 @@ case class RuntimeArray(array: ListBuffer[RuntimeValue]= new ListBuffer) extends
   override def toString = array.mkString(", ")
   def get(index: Long):RuntimeValue = {
     if (index<=0) throw new FimException("Negative page")
-    if (index>array.size) RuntimeNull
-    array(index.toInt-1)
+    if (index>array.size) {
+      RuntimeNull
+    } else {
+      array(index.toInt-1)
+    }
   }
   def set(index: Long, value: RuntimeValue) {
     while(array.size<index) array += RuntimeNull


### PR DESCRIPTION
For instance, the following program throws `java.lang.IndexOutOfBoundsException` instead of
setting `Errors` to nothing:

```
I found a book titled Debugging. On 1st page of Debugging I read about Errors.
```

This change also fixes the `bf.fimpp` example, which right now just throws the above exception.