### PR TITLE
Fix ambiguity in conjunctions and tuple literals.

### DIFF
--- a/syntax/Conditional expressions.md
+++ b/syntax/Conditional expressions.md
@@ -52,3 +52,8 @@ Conjunction
     <simple condition> and <simple condition>
     <simple condition>, <simple condition> and <simple condition>
     ...
+
+There is some ambiguity between conjuction and tuple syntaxes. Don't try to use
+tuple literals in conjuctions. For instance, this won't work:
+
+    I did this while numbers were equal to one and two and letters were equal...

--- a/test/UnitTests.scala
+++ b/test/UnitTests.scala
@@ -11,6 +11,14 @@ object UnitTests {
   def main(a: Array[String]) {
     println(FimppParser.parseAll(FimppParser.condition,
       "applejack has more than one".toLowerCase()))
+    println(FimppParser.parseAll(FimppParser.condition,
+      "applejack has more than one or pinkie pie has more than one"))
+    println(FimppParser.parseAll(FimppParser.condition,
+      "applejack has more than one and pinkie pie has more than one"))
+    println(FimppParser.parseAll(FimppParser.condition,
+      "applejack is equal to one and pinkie pie has more than one"))
+    println(FimppParser.parseAll(FimppParser.condition,
+      "applejack is equal to one and two"))
     println(FimppParser.parseAll(FimppParser.identifier~FimppParser.kw("i")|FimppParser.kw("x")~FimppParser.kw("i"),
       "x i".toLowerCase()))
     println(FimppParser.parseAll(FimppParser.stringLiteral,


### PR DESCRIPTION
This change removes the possibility of using tuple literals in the beginning of a conjuction conditional. This  fixes issue #8.

For example, consider this valid conditional:

```
Applejack has more than one and Pinkie Pie has more than one
```

Without this change, `one and Pinkie Pie` will be parsed as a tuple literal, which then causes the parser to fail on the `has` keyword. The syntax itself doesn't seem ambiguous in this particular case. However, the parser only fails at the `andCondition`, so it won't try to reparse `one` as a `simpleExpression` instead of a `listExpression`.

It might be possible to fix the parser to correctly parse this while retaining the possibility of having tuple literals. Removing literals seems simpler though.